### PR TITLE
fix: type of return value in WordCountTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TextTools Plugin For Dify
 
 **Author:** yizixuan
-**Version:** 0.0.3
+**Version:** 0.0.5
 **Type:** tool
 
 https://github.com/sqkkyzx/dify-plugin-text_tools

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 type: plugin
 author: yizixuan
 name: text_tools

--- a/tools/word_count.py
+++ b/tools/word_count.py
@@ -54,6 +54,6 @@ class WordCountTool(Tool):
 
             yield self.create_json_message(json=result)
             for key, value in result.items():
-                yield self.create_variable_message(variable_name=key, variable_value=str(value))
+                yield self.create_variable_message(variable_name=key, variable_value=value)
         except Exception as e:
             yield self.create_text_message(f"Failed to count words, error: {str(e)}")


### PR DESCRIPTION
- The return value of `WordCountTool` should be `int` instead of `str`
- bump version to v0.0.5